### PR TITLE
chore: Update Speakeasy doc version to v3.1.0

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -2,7 +2,7 @@ lockVersion: 2.0.0
 id: 1e0c88f5-b1c8-4198-83d8-36bd00451cd3
 management:
   docChecksum: 2303b8447e474d428256a66f5ab2f945
-  docVersion: v3.0.5
+  docVersion: v3.1.0
   speakeasyVersion: 1.617.1
   generationVersion: 2.701.8
   releaseVersion: 6.4.0

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -7,7 +7,7 @@ sources:
         tags:
             - latest
             - speakeasy-sdk-regen-1754440427
-            - v3.0.5
+            - v3.1.0
 targets:
     formance-python-sdk:
         source: stacks-source
@@ -22,7 +22,7 @@ workflow:
     sources:
         stacks-source:
             inputs:
-                - location: https://github.com/formancehq/stack/releases/download/v3.0.5/generate.json
+                - location: https://github.com/formancehq/stack/releases/download/v3.1.0/generate.json
             registry:
                 location: registry.speakeasyapi.dev/formance/formance/stacks-source
     targets:

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,7 +3,7 @@ speakeasyVersion: latest
 sources:
     stacks-source:
         inputs:
-            - location: https://github.com/formancehq/stack/releases/download/v3.0.5/generate.json
+            - location: https://github.com/formancehq/stack/releases/download/v3.1.0/generate.json
         registry:
             location: registry.speakeasyapi.dev/formance/formance/stacks-source
 targets:


### PR DESCRIPTION
## Summary
- Updates the docVersion in .speakeasy/gen.lock from v3.0.5 to v3.1.0

## Test plan
- [ ] Verify the version has been updated in .speakeasy/gen.lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)