### PR TITLE
chore: upgrade OpenAPI spec to v3.2.0

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,7 +3,7 @@ speakeasyVersion: latest
 sources:
     stacks-source:
         inputs:
-            - location: https://github.com/formancehq/stack/releases/download/v3.1.0/generate.json
+            - location: https://github.com/formancehq/stack/releases/download/v3.2.0/generate.json
         registry:
             location: registry.speakeasyapi.dev/formance/formance/stacks-source
 targets:


### PR DESCRIPTION
## Summary
- Upgrade OpenAPI specification from v3.1.0 to v3.2.0
- Source: https://github.com/formancehq/stack/releases/download/v3.2.0/generate.json