### PR TITLE
feat: switch OpenAPI source to Speakeasy Registry

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,7 +3,7 @@ speakeasyVersion: latest
 sources:
     stacks-source:
         inputs:
-            - location: https://github.com/formancehq/stack/releases/download/v3.2.0/generate.json
+            - location: registry.speakeasyapi.dev/formance/formance/stacks-source@latest
         registry:
             location: registry.speakeasyapi.dev/formance/formance/stacks-source
 targets:


### PR DESCRIPTION
## Summary
- Switch OpenAPI spec source from GitHub release download to Speakeasy Registry (`registry.speakeasyapi.dev/formance/formance/stacks-source@latest`)
- The overlaid spec is now published centrally from the `stack` repo, ensuring all SDKs consume a single corrected source

## Test plan
- [ ] Verify Speakeasy SDK generation succeeds with the registry source